### PR TITLE
Add confirm to allowed global variables

### DIFF
--- a/lib/zendesk_apps_support/validations/source.rb
+++ b/lib/zendesk_apps_support/validations/source.rb
@@ -14,7 +14,7 @@ module ZendeskAppsSupport
         sub: true,
 
         # predefined globals:
-        predef: %w(_ console services helpers alert window document self
+        predef: %w(_ console services helpers alert confirm window document self
                    JSON Base64 clearInterval clearTimeout setInterval setTimeout
                    require module exports top frames parent moment)
       }.freeze


### PR DESCRIPTION
`confirm` is a built in javascript function, it should be allowed within zendesk applications.

If you'd like me to submit this somewhere else, please let me know.  Or if you'd prefer to do this yourself, that is also fine.  However this is an immediate blocker to the private application that I have been developing.